### PR TITLE
Space missing before RED DOT

### DIFF
--- a/themes/Default.bgptheme
+++ b/themes/Default.bgptheme
@@ -42,7 +42,7 @@ define_undefined_git_prompt_colors() {
   if [[ -z ${GIT_PROMPT_SEPARATOR} ]]; then GIT_PROMPT_SEPARATOR="|"; fi              # separates each item
 
   if [[ -z ${GIT_PROMPT_BRANCH} ]]; then GIT_PROMPT_BRANCH="${Magenta}"; fi        # the git branch that is active in the current directory
-  if [[ -z ${GIT_PROMPT_STAGED} ]]; then GIT_PROMPT_STAGED="${Red}●"; fi           # the number of staged files/directories
+  if [[ -z ${GIT_PROMPT_STAGED} ]]; then GIT_PROMPT_STAGED="${Red}● "; fi           # the number of staged files/directories
   if [[ -z ${GIT_PROMPT_CONFLICTS} ]]; then GIT_PROMPT_CONFLICTS="${Red}✖ "; fi       # the number of files in conflict
   if [[ -z ${GIT_PROMPT_CHANGED} ]]; then GIT_PROMPT_CHANGED="${Blue}✚ "; fi        # the number of changed files
 


### PR DESCRIPTION
The n of staged changes was too close to the red DOT

In line 45 of Default.bgptheme is missing a space.

 - if [[ -z ${GIT_PROMPT_STAGED} ]]; then GIT_PROMPT_STAGED="${Red}●"; fi           # the number of staged files/directories
+  if [[ -z ${GIT_PROMPT_STAGED} ]]; then GIT_PROMPT_STAGED="${Red}● "; fi           # the number of staged files/directories